### PR TITLE
Support more captcha extensions

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -285,7 +285,7 @@ class ModJDSimpleContactFormHelper {
       }
       // BCC
       $bcc = !empty($params->get('email_bcc', '')) ? $params->get('email_bcc') : '';
-      $bcc = explode(',', $bcc);
+      $bcc = empty($bcc) ? [] : explode(',', $bcc);
       if (!empty($bcc)) {
          $mailer->addBcc($bcc);
       }

--- a/helper.php
+++ b/helper.php
@@ -88,7 +88,7 @@ class ModJDSimpleContactFormHelper {
             }
          } elseif ( $captchaType == "recaptcha_invisible" ) {
             $check_captcha = $dispatcher->trigger('onCheckAnswer', $jinput->get('g-recaptcha-response'));
-         } elseif ( $captchaType == "aimycaptchalessformguard" ) {
+         } elseif (!empty($captchaType)) {
             $check_captcha = $dispatcher->trigger('onCheckAnswer');
          }
       }

--- a/helper.php
+++ b/helper.php
@@ -88,6 +88,8 @@ class ModJDSimpleContactFormHelper {
             }
          } elseif ( $captchaType == "recaptcha_invisible" ) {
             $check_captcha = $dispatcher->trigger('onCheckAnswer', $jinput->get('g-recaptcha-response'));
+         } elseif ( $captchaType == "aimycaptchalessformguard" ) {
+            $check_captcha = $dispatcher->trigger('onCheckAnswer');
          }
       }
 
@@ -131,6 +133,13 @@ class ModJDSimpleContactFormHelper {
       $contents = [];
       $attachments = [];
       $errors = [];
+      // Get all error messages and add them to $errors variable
+      $messages = $app->getMessageQueue();
+      if (!empty($messages)) {
+         for ($i=0; $i < count($messages); $i++) { 
+            $errors[] = $messages[$i]["message"];
+         }
+      }
       foreach ($labels as $name => $fld) {
          $value = isset($values[$name]) ? $values[$name] : '';
 

--- a/language/nl-NL/nl-NL.mod_jdsimplecontactform.ini
+++ b/language/nl-NL/nl-NL.mod_jdsimplecontactform.ini
@@ -1,0 +1,217 @@
+JGLOBAL_CUSTOM="Custom"
+JGLOBAL_VERTICAL="Verticaal"
+JGLOBAL_INLINE="Inline"
+JINVALID_TOKEN="Token is niet geldig"
+
+MOD_JDSIMPLECONTACTFORM="JD Simpel Contact Formulier"
+MOD_JDSIMPLECONTACTFORM_XML_DESCRIPTION="JD Simpel Contact formulier biedt een simpel formulieren framework aan met daarbij de minimale opties die nodig zijn om formulieren in Joomla te kunnen gebruiken.<br><br>
+Het volgende zit er in:
+<ul>
+<li>Oneindig aantal formulier velden./li>
+<li>10+ verschillende veld types.</li>
+<li>Mogelijkheid om velden verplicht te maken met een aan te passen error boodschap.</li>
+<li>Mogelijkheid om velden te ordenen.</li>
+<li>Mogelijkheid om een bedankt boodschap in te stellen.</li>
+<li>Mogelijkheid om naar een andere pagina door te sturen na het indienen van het formulier.</li>
+<li>Eigen email berichten zijn in te stellen.</li>
+<li>Mogelijkheid om CC, BCC, Reply-To berichten in te stellen.</li>
+<li>Mogelijk om via Ajax formulier in te dienen.</li>
+<li>Voeg de IP informatie toe aan de email template.</li>
+<li>Ondersteund zowel reCAPTCHA en Invisible reCAPTCHA.</li>
+</ul>"
+
+
+MOD_JDSCF_FIELDS_LBL="Formulier Velden"
+
+MOD_JDSCF_FORM_TITLE_LBL="Titel"
+MOD_JDSCF_FORM_TITLE_DESC="Titel van jouw formulier, deze zal bovenaan het formulier getoond worden."
+
+MOD_JDSCF_FORM_DESCRIPTION_LBL="Beschrijving"
+MOD_JDSCF_FORM_DESCRIPTION_DESC="Beschrijving van jouw formulier, deze zal meteen na de titel getoond worden, maar voor alle velden."
+
+MOD_JDSCF_NAME_LBL="Naam"
+MOD_JDSCF_NAME_DESC="Vul de naam van het veld in.<br>(<b><i>Moet uniek zijn, alleen letters en nummers zijn toegestaan.</i></b>)<br>(<b>Je kunt deze naam gebruiken om veld inhoud te tonen in de Bedankt boodschap, redirect url, email template en email onderwerp</b>)"
+
+MOD_JDSCF_AJAX_LBL="Activeer Ajax"
+MOD_JDSCF_AJAX_DESC="Vink aan om via Ajax in te dienen, de pagina wordt dan niet ververst nadat het formulier is ingediend."
+
+MOD_JDSCF_CAPTCHA_LBL="Activeer Captcha"
+MOD_JDSCF_CAPTCHA_DESC="Selecteer om Captcha aan te zetten."
+
+MOD_JDSCF_LABEL_LBL="Label"
+MOD_JDSCF_LABEL_DESC="Vul een label voor het veld in."
+
+MOD_JDSCF_VALUE_LBL="Waarde"
+MOD_JDSCF_VALUE_DESC="Vul een waarde in voor het verborgen veld."
+
+MOD_JDSCF_SHOW_LABEL_LBL="Toon Label"
+MOD_JDSCF_SHOW_LABEL_DESC="Selecteer om de label voor het veld te tonen."
+
+MOD_JDSCF_OPTIONS_LAYOUT_LBL="Options Opmaak"
+MOD_JDSCF_OPTIONS_LAYOUT_DESC="Selecteer om vink velden en radio velden in verticaal of horizontaal te tonen."
+
+MOD_JDSCF_FORM_SUBMIT_LBL="Indien Knop Tekst"
+MOD_JDSCF_FORM_SUBMIT_DESC="Vul een tekst in voor de indien knop. Default is <b>Indienen</b>."
+MOD_JDSCF_FORM_SUBMIT_DEFAULT="Indienen"
+
+MOD_JDSCF_REQUIRED_LBL="Verplicht"
+MOD_JDSCF_REQUIRED_DESC="Selecteer om het veld verplicht te maken."
+
+MOD_JDSCF_CUSTOM_ERROR_LBL="Verplicht veld error boodschap"
+MOD_JDSCF_CUSTOM_ERROR_DESC="Vul een boodschap in die getoond wordt als een veld verplicht is."
+
+MOD_JDSCF_TYPE_LBL="Type"
+MOD_JDSCF_TYPE_DESC="Selecteer het type veld."
+
+MOD_JDSCF_WIDTH_LBL="Breedte"
+MOD_JDSCF_WIDTH_DESC="Selecteer een breedte tussen 2 - 12, Dit is gebasseerd op het bootstrap grid system, Meer informatie is te vinden op <a href="https://getbootstrap.com/docs/">https://getbootstrap.com/docs/</a>."
+
+MOD_JDSCF_SUBMIT_WIDTH_LBL="Indien knop breedte"
+MOD_JDSCF_SUBMIT_WIDTH_DESC="Selecteer een breedte tussen 2 - 12, Dit is gebasseerd op het bootstrap grid system, Meer informatie is te vinden op <a href="https://getbootstrap.com/docs/">https://getbootstrap.com/docs/</a>."
+
+MOD_JDSCF_PLACEHOLDER_LBL="Placeholder"
+MOD_JDSCF_PLACEHOLDER_DESC="Vul een waarde in als je een placeholder tekst wilt tonen."
+
+MOD_JDSCF_TYPE_TEXT_LBL="Tekst"
+MOD_JDSCF_TYPE_EMAIL_LBL="Email"
+MOD_JDSCF_TYPE_NUMBER_LBL="Nummer"
+MOD_JDSCF_TYPE_URL_LBL="URL"
+MOD_JDSCF_TYPE_TEXTAREA_LBL="Tekst gebied"
+MOD_JDSCF_TYPE_FILE_LBL="Bestand (uploaden)"
+MOD_JDSCF_TYPE_RADIO_LBL="Radio"
+MOD_JDSCF_TYPE_CHECKBOX_LBL="Vink veld"
+MOD_JDSCF_TYPE_CHECKBOXES_LBL="Vink velden"
+MOD_JDSCF_TYPE_CALENDAR_LBL="Kalendar"
+MOD_JDSCF_TYPE_LIST_LBL="Lijst"
+MOD_JDSCF_TYPE_HIDDEN_LBL="Verborgen"
+
+MOD_JDSCF_OPTIONS_LBL="Opties"
+MOD_JDSCF_OPTIONS_DESC="Vul de retour scheidingswaardes in."
+
+MOD_JDSCF_CSS_LBL="Laad CSS"
+MOD_JDSCF_CSS_DESC=""
+
+MOD_JDSCF_IPADDR_LBL="Voeg IP Adres toe"
+MOD_JDSCF_IPADDR_DESC="Verzameld het IP adres van de gebruiker en voegt deze toe in de email voor de admin."
+
+MOD_JDSCF_REQUIRED_ERROR="%s is verplicht."
+MOD_JDSCF_NUMBER_MIN_LENGTH_ERROR="%s moet %s karakters of meer hebben."
+MOD_JDSCF_NUMBER_MAX_LENGTH_ERROR="%s moet %s karakters of minder hebben."
+MOD_JDSCF_NUMBER_MIN_ERROR="%s moet groter of gelijk zijn aan %s."
+MOD_JDSCF_NUMBER_MAX_ERROR="%s moet kleiner of gelijk zijn aan %s."
+MOD_JDSCF_FILE_BTN_LBL="Kies een bestand."
+
+MOD_JDSCF_MIN_LENGTH_LBL="Minimale Lengte"
+MOD_JDSCF_MIN_LENGTH_DESC="Vul een nummer in als je een wilt dat een veldwaarde een minimaal aantal karakters moet hebben."
+MOD_JDSCF_MAX_LENGTH_LBL="Maximale Lengte"
+MOD_JDSCF_MAX_LENGTH_DESC="Vul een nummer in als je een wilt dat een veldwaarde een maximaal aantal karakters moet hebben."
+MOD_JDSCF_MIN_LBL="Minimale Waarde"
+MOD_JDSCF_MIN_DESC="Vul een nummer in, als je wilt dat de input groter moet zijn dan de minimale waarde (b.v. <b>Als je hier 100 invult, dan kan de gebruiker het formulier niet indienen, zolang de waarde kleiner is dan 100.</b>)"
+MOD_JDSCF_MAX_LBL="Maximale Waarde"
+MOD_JDSCF_MAX_DESC="Vul een nummer in, als je wilt dat de input kleiner moet zijn dan de minimale waarde (b.v. <b>Als je hier 100 invult, dan kan de gebruiker het formulier niet indienen, zolang de waarde groter is dan 100.</b>)"
+
+MOD_JDSCF_FORM_FIELDS_OPTIONS_LBL="Formulier Opmaak"
+MOD_JDSCF_EMAIL_OPTIONS_LBL="Email Opties"
+
+MOD_JDSCF_EMAIL_FROM_LBL="Van Email"
+MOD_JDSCF_EMAIL_FROM_DESC="Vul het Van email adres in"
+
+MOD_JDSCF_EMAIL_NAME_LBL="Van Naam"
+MOD_JDSCF_EMAIL_NAME_DESC="Vul de naam in die getoond wordt als afzender van de email."
+
+MOD_JDSCF_EMAIL_SUBJECT_LBL="Email Beschrijving"
+MOD_JDSCF_EMAIL_SUBJECT_DESC="Onderwerp van de email (<b>Je kunt {field:label} & {field:value} gebruiken om dynamische waardes in dit veld te tonen</b>)."
+
+MOD_JDSCF_EMAIL_TO_LBL="Email Adres"
+MOD_JDSCF_EMAIL_TO_DESC="Vul het email adres in om ingediende formulieren te ontvangen. Gebruik komma's om meerdere mailadressen te scheiden."
+
+MOD_JDSCF_REPLY_TO_LBL="Reply-to Email"
+MOD_JDSCF_REPLY_TO_DESC="Vul het Reply-to email adres in."
+
+MOD_JDSCF_EMAIL_CC_LBL="CC Email"
+MOD_JDSCF_EMAIL_CC_DESC="CC email adres om ingediende formulieren te ontvangen. Gebruik komma's om meerdere mailadressen te scheiden."
+
+MOD_JDSCF_EMAIL_BCC_LBL="BCC Email"
+MOD_JDSCF_EMAIL_BCC_DESC="BCC email adres om ingediende formulieren te ontvangen. Gebruik komma's om meerdere mailadressen te scheiden."
+
+MOD_JDSCF_EMAIL_TEMPLATE_LBL="Email Template"
+MOD_JDSCF_EMAIL_TEMPLATE_DESC="Selecteer de email template, De <b>default</b> template toont alle velden in de volgorde zoals ze in het formulier getoond worden volgens het formaat <br><b>{field:label}: {field:value}</b></br>."
+
+; Months for Calendar
+MOD_JDSCF_JANUARY="Januari"
+MOD_JDSCF_FEBRUARY="Februari"
+MOD_JDSCF_MARCH="Maart"
+MOD_JDSCF_APRIL="April"
+MOD_JDSCF_MAY="Mei"
+MOD_JDSCF_JUNE="Juni"
+MOD_JDSCF_JULY="Juli"
+MOD_JDSCF_AUGUST="Augustus"
+MOD_JDSCF_SEPTEMBER="September"
+MOD_JDSCF_OCTOBER="Oktober"
+MOD_JDSCF_NOVEMBER="November"
+MOD_JDSCF_DECEMBER="December"
+
+; Weekdays for Calendar
+MOD_JDSCF_MONDAY="Maandag"
+MOD_JDSCF_TUESDAY="Dinsdag"
+MOD_JDSCF_WEDNESDAY="Woensdag"
+MOD_JDSCF_THURSDAY="Donderdag"
+MOD_JDSCF_FRIDAY="Vrijdag"
+MOD_JDSCF_SATURDAY="Zaterdag"
+MOD_JDSCF_SUNDAY="Zondag"
+
+; Short Weekdays for Calendar
+MOD_JDSCF_MON="MA"
+MOD_JDSCF_TUE="DI"
+MOD_JDSCF_WED="WOE"
+MOD_JDSCF_THUR="DO"
+MOD_JDSCF_FRI="VRIJ"
+MOD_JDSCF_SAT="ZAT"
+MOD_JDSCF_SUN="ZON"
+
+; Single Email Fields
+MOD_JDSCF_SINGLE_SEND_COPY="Stuur een kopie van de Email"
+MOD_JDSCF_SINGLE_SEND_COPY_LBL_TITLE="Stuur mij een kopie"
+MOD_JDSCF_SINGLE_SEND_COPY_DESCRIPTION="Toon een vink veld onder aan het formulier voor gebruikers om een kopie naar zichzelf te sturen."
+MOD_JDSCF_SINGLE_SEND_COPY_EMAIL_FIELD_LABEL="Vul een label in voor het Email Veld"
+MOD_JDSCF_SINGLE_SEND_COPY_EMAIL_FIELD_DESC="Vul de naam in van het formulier veld van de <b>Formulier Opmaak</b> op basis waarvan je een kopie wilt versturen."
+MOD_JDSCF_SINGLE_SEND_COPY_LABEL="Vul een Stuur Kopie label in"
+MOD_JDSCF_SINGLE_SEND_COPY_DESC="Label om te tonen voor het vink veld."
+
+MOD_JDSCF_EMAIL_NAME="Vul de naam van de email in"
+MOD_JDSCF_EMAIL_NAME_DESCRIPTION="Naam van het email veld waar een kopie naar toegestuurd moet worden."
+
+MOD_JDSCF_EMAIL_CUSTOM_TEMPLATE_LBL="Eigen Email Template"
+MOD_JDSCF_EMAIL_CUSTOM_TEMPLATE_DESC="Vul een eigen email template in. Je kunt <b>{field:label}</b> gebruiken voor de veldnaam, en <b>{field:value}</b> voor de veld waarde. Verander <b>field</b> naar de ingestelde naam van het veld."
+
+MOD_JDSCF_THANKYOU_MESSAGE_LBL="Bedankt boodschap"
+MOD_JDSCF_THANKYOU_MESSAGE_DESC="Vul een bedankt boodschap in, die getoond wordt nadat het formulier is ingediend. 
+Laat leeg om niets te tonen.(<b>Je kunt {field:label} & {field:value} gebruiken om dynamische waardes in dit veld te tonen</b>)"
+
+MOD_JDSCF_REDIRECT_LBL="Redirect URL"
+MOD_JDSCF_REDIRECT_DESC="Vul een url in om naar te redirecten, nadat het formulier is ingediend. Laat leeg als dit niet nodig is. (<b>Je kunt {field:label} & {field:value} gebruiken om dynamische waardes te tonen in dit veld.</b>)"
+
+MOD_JDSCF_SUBMITBTN_CLASS_LBL="Indien Knop Class"
+MOD_JDSCF_SUBMITBTN_CLASS_DESC=""
+
+MOD_JDSCF_UNSUPPORTED_FILE_ERROR="Niet ondersteund bestandstype"
+MOD_JDSCF_UNSUPPORTED_MAIL_CLIENT_ERROR="Het is niet gelukt om de mail te versturen."
+MOD_JDSCF_AJAX_ERROR_ON_SUBMIT="Oeps, er ging iets mis. Probeer het nog eens."
+MOD_JDSCF_NOTICE_ON_COOKIES_DISABLED="Cookies zijn uitgezet in jouw browser. Zet cookies aan en probeer het opnieuw. <u><a href='https://support.google.com/accounts/answer/61416?hl=en-GB'>Meer informatie</a></u>"
+
+MOD_JDSCF_DEFAULT_SUBJECT="Nieuw ingediend formulier."
+
+MOD_JDSCF_TEXTAREA_ROWS_LBL="Rijen"
+MOD_JDSCF_TEXTAREA_ROWS_DESC=""
+MOD_JDSCF_CAPTCHA_TYPE_LBL="Captcha Type"
+MOD_JDSCF_CAPTCHA_TYPE_DESC="Selecteer Type Captcha"
+MOD_JDSCF_THANKYOU_DEFAULT="<div class='alert alert-success'>Bedankt voor het indienen!</div>"
+MOD_JDSCF_BAD_REQUEST="Bad Request"
+MOD_JDSCFEMAIL_SEND_ERROR="Er was een error bij het verzenden van de mail."
+MOD_JDSCF_MODULE_NOT_FOUND="Module niet gevonden"
+MOD_JDSCF_OPTIONS_CALENDAR_MIN_LBL="Mininmale datum"
+MOD_JDSCF_OPTIONS_CALENDAR_MIN_DESC="De minimale/vroegste datum die geselecteerd kan worden"
+MOD_JDSCF_OPTIONS_CALENDAR_MAX_LBL="Maximum datum"
+MOD_JDSCF_OPTIONS_CALENDAR_MAX_DESC="De maximum/laatste datum die geselecteerd kan worden"
+MOD_JDSCF_OPTIONS_CALENDAR_DATE_FOMRAT_LBL="Datum Formaat"
+MOD_JDSCF_OPTIONS_CALENDAR_DATE_FOMRAT_DESC="Dit gaat gebruikt worden om datum velden te formateren<br/><br/><table width="260" border="1" cellspacing="0">   <tr>      <td>DD</td>      <td>Dag van de maand, 2 getallen met voorloop nullen</td>      <td>01 tot 31</td>   </tr>   <tr>      <td>ddd</td>      <td>Een tekst weergavevan de dag</td>      <td>Ma tot en met Zon</td>   </tr>   <tr>      <td>dddd</td>      <td>Een volledige weergave van de naam van de dag</td>      <td>Zondag tot en met Zaterdag</td>   </tr>   <tr>      <td>Do</td>      <td>Afkorting met de dag van de maand, 2 karakters met datum.</td>      <td>st, nd, rd or th</td>   </tr>   <tr>      <td>Do</td>      <td>Dag van e maand, 2 karakters met datum.</td>      <td>01ste, 02de, 03de or Nde</td>   </tr>   <tr>      <td>MM</td>      <td>Numerieke weergave van de maand met voorloop nullen</td>      <td>01 tot en met 12</td>   </tr>   <tr>      <td>MMM</td>      <td>Een korte textuele weergave van de maand</td>      <td>Jan tot en met Dec</td>   </tr>   <tr>      <td>MMMM</td>      <td>Een volledige tekstweergave van de maand, zoals Januari of Maart</td>      <td>Januari tot en met December</td>   </tr>   <tr>      <td>YY</td>      <td>Jaarweergave met 2 getallen</td>      <td>99 of 03</td>   </tr>   <tr>      <td>YYYY</td>      <td>Een volledige weergave van het jaar, 4 getallen</td>      <td>1999 of 2003</td>   </tr></table>"

--- a/language/nl-NL/nl-NL.mod_jdsimplecontactform.sys.ini
+++ b/language/nl-NL/nl-NL.mod_jdsimplecontactform.sys.ini
@@ -1,0 +1,17 @@
+MOD_JDSIMPLECONTACTFORM="JD Simpel Contact Formulier"
+MOD_JDSIMPLECONTACTFORM_XML_DESCRIPTION="JD Simpel Contact formulier biedt een simpel formulieren framework aan met daarbij de minimale opties die nodig zijn om formulieren in Joomla te kunnen gebruiken.<br><br>
+Het volgende zit er in:
+<ul>
+<li>Oneindig aantal formulier velden./li>
+<li>10+ verschillende veld types.</li>
+<li>Mogelijkheid om velden verplicht te maken met een aan te passen error boodschap.</li>
+<li>Mogelijkheid om velden te ordenen.</li>
+<li>Mogelijkheid om een bedankt boodschap in te stellen.</li>
+<li>Mogelijkheid om naar een andere pagina door te sturen na het indienen van het formulier.</li>
+<li>Eigen email berichten zijn in te stellen.</li>
+<li>Mogelijkheid om CC, BCC, Reply-To berichten in te stellen.</li>
+<li>Mogelijk om via Ajax formulier in te dienen.</li>
+<li>Voeg de IP informatie toe aan de email template.</li>
+<li>Ondersteund zowel reCAPTCHA en Invisible reCAPTCHA.</li>
+</ul>
+"

--- a/mod_jdsimplecontactform.xml
+++ b/mod_jdsimplecontactform.xml
@@ -13,6 +13,8 @@
    <languages folder="language">
       <language tag="en-GB">en-GB/en-GB.mod_jdsimplecontactform.ini</language>
       <language tag="en-GB">en-GB/en-GB.mod_jdsimplecontactform.sys.ini</language>
+      <language tag="nl-NL">nl-NL/nl-NL.mod_jdsimplecontactform.ini</language>
+      <language tag="nl-NL">nl-NL/nl-NL.mod_jdsimplecontactform.sys.ini</language>
    </languages>   
    <files>
       <filename>mod_jdsimplecontactform.xml</filename>

--- a/tmpl/default.php
+++ b/tmpl/default.php
@@ -76,7 +76,19 @@ if (!empty($message)) {
                         <div id='recaptcha' class="g-recaptcha" data-sitekey="<?php echo $plugin_params->get('public_key', ''); ?>"  data-size="invisible"></div>
                      <?php
                      }
-                  } 
+                  } elseif ( $captchaType == "aimycaptchalessformguard" ) {
+                     // Display captcha plugin fields
+                     if (!empty($plugin)) {
+                        $plugin_params = new JRegistry($plugin->params);
+                        $captchaHtml = $dispatcher->trigger('onDisplay', array('jdscf_recaptcha_' . $module->id, 'jdscf_recaptcha_' . $module->id));
+                        if (!empty($captchaHtml)) {
+                           foreach ($captchaHtml as $cHtml) {
+                              // Add captcha generated html to page
+                              echo $cHtml;
+                           }
+                        }
+                     }
+                  }
                }
             ?>
             

--- a/tmpl/default.php
+++ b/tmpl/default.php
@@ -76,16 +76,24 @@ if (!empty($message)) {
                         <div id='recaptcha' class="g-recaptcha" data-sitekey="<?php echo $plugin_params->get('public_key', ''); ?>"  data-size="invisible"></div>
                      <?php
                      }
-                  } elseif ( $captchaType == "aimycaptchalessformguard" ) {
+                  } elseif ( !empty($captchaType) ) {
                      // Display captcha plugin fields
                      if (!empty($plugin)) {
                         $plugin_params = new JRegistry($plugin->params);
                         $captchaHtml = $dispatcher->trigger('onDisplay', array('jdscf_recaptcha_' . $module->id, 'jdscf_recaptcha_' . $module->id));
                         if (!empty($captchaHtml)) {
-                           foreach ($captchaHtml as $cHtml) {
-                              // Add captcha generated html to page
-                              echo $cHtml;
-                           }
+                           ?>
+                           <div class="jdscf-col-md-12">
+                              <div class="form-group">
+                                 <?php
+                                 foreach ($captchaHtml as $cHtml) {
+                                    // Add captcha generated html to page
+                                    echo $cHtml;
+                                 }
+                                 ?>
+                              </div>
+                           </div>
+                           <?php
                         }
                      }
                   }


### PR DESCRIPTION
Because I wan't to use this extension with non-google captcha's, I would like to see more captcha's supported. While busy, I also saw an error when no BCC address is configured and added dutch language files.
Proposed changes:
- Adding support for multiple captcha extensions
- Adding dutch language files
- Check if configured BCC address is empty. Without this check there will be a silent error

Do you agree on adding support for more captcha's?